### PR TITLE
Initial work on comment file model

### DIFF
--- a/src/architecture.ts
+++ b/src/architecture.ts
@@ -1,0 +1,195 @@
+/**
+ * ### About this file
+ * **This is a high-level overview of how the generalized comment system will work in
+ * JupyterLab. It's a living document and subject to change. Also, any code or interfaces
+ * here shouldn't actually be used--it's just for mapping out ideas.**
+ *
+ * ### High-level overview
+ * Comments are stored in .comment files in a dedicated folder server-side.
+ * Each .comment file is named based on the hash of the target file's path.
+ * The comment files contain an array of `IComment` objects that describe comments.
+ *
+ * When the comment panel is opened or the current document changes, the corresponding
+ * .comment file is loaded into an `ICommentModel` and the array of `IComment` objects
+ * is used to populate the panel.
+ *
+ * Each comment has a type and a target. The type is used to retrieve an `ICommentFactory`
+ * from the `ICommentRegistry`. The factory is used to locate the target and render
+ * an `ICommentWidget` based on the `IComment`. Changes to the comments (insertions,
+ * deletions, edits, etc) are made in the shared ydoc of the `ICommentModel`. Changes also
+ * cause a changed signal to be emitted by the model, which is listened to by each client's
+ * `ICommentPanel` and used to update the comments in real-time.
+ *
+ * ### Adding comment support to other file types
+ * Adding support for comments to files is accomplished with an `ICommentPanel` token.
+ * The token gives access to the `ICommentRegistry`, as well as the current
+ * `ICommentModel`. Factories for file-specific comment types are registered in the
+ * comment registry, then the `addComment`, `deleteComment` etc methods of the current
+ * comment model can be used.
+ *
+ * ### Some sticking points
+ * Finding the original target of a comment can be difficult after it's loaded from a file.
+ * The comment factory for each type of comment will have to describe some target->JSON and
+ * JSON->target function. There should also be some easy way to scroll to/highlight the target.
+ * A possible solution is to define two functions: one which returns the HTMLElement closest
+ * assosciated with a target (for scrolling) and an optional one which defines a fragment/slice
+ * of the HTMLElement target (for selecting). Both functions can take the JSON representation
+ * of the target as an argument.
+ */
+
+import { IComment, IIdentity, IReply } from './commentformat';
+import { ISignal } from '@lumino/signaling';
+import { Menu } from '@lumino/widgets';
+import * as models from '@jupyterlab/shared-models';
+import { Awareness } from 'y-protocols/awareness';
+import { CommentWidget } from './widget';
+import { PartialJSONValue } from '@lumino/coreutils';
+import { ICommentRegistry } from './registry';
+
+/**
+ * An object for interacting with a comment file. Manages the file's path, id, factories, etc.
+ * Ideally, this represents a simple top-level API for commenting.
+ */
+export interface ICommentFileModel {
+  // Create an `IComment` given `options` and the model's configuration.
+  createComment: (options: ICommentOptions) => IComment;
+
+  // Create an `IReply` given options and the model's configuration.
+  createReply: (options: IReplyOptions) => IReply;
+
+  // Same as `createComment` but also add the comment to the comment file.
+  addComment: (options: ICommentOptions) => void;
+
+  // Same as `createReply` but also add the reply to a comment in the comment file.
+  addReply: (options: IReplyOptions) => void;
+
+  // Delete the comment with id `id`
+  deleteComment: (id: string) => void;
+
+  // Delete the reply with id `id` (parentID is id of parent comment; optional)
+  deleteReply: (id: string, parentID?: string) => void;
+
+  // Apply the changes in `options` to the comment with id `id`
+  editComment: (
+    options: Partial<Exclude<ICommentOptions, 'id'>>,
+    id: string
+  ) => void;
+
+  // Apply the changes in `options` to the reply with id `id` (parentID is id of parent comment; optional)
+  editReply: (
+    options: Partial<Exclude<IReplyOptions, 'id'>>,
+    id: string,
+    parentID?: string
+  ) => void;
+
+  // Path to the comment file.
+  path: string;
+
+  // Path to the file being commented on.
+  sourcePath: string;
+
+  // The id of the comment file.
+  id: string;
+
+  // The underlying object handling RTC.
+  ydoc: models.YDocument<any>;
+
+  // The in-memory representation of the comments being managed by the model.
+  // Basically just `this.ydoc.getArray('comments')`
+  comments: IComment[];
+
+  // The dropdown menu for comment widgets. There will be a default menu.
+  commentMenu: Menu;
+
+  // The awareness associated with the file being commented on.
+  awareness: Awareness;
+
+  // Whether the model is currently rendered in the comment panel.
+  inPanel: boolean;
+
+  // The comment factory registry
+  registry: ICommentRegistry;
+}
+
+/**
+ * An object for displaying `CommentWidget`s.
+ */
+export interface ICommentPanel {
+  // The file model containing the comments currently being rendered to the panel.
+  model: ICommentFileModel;
+
+  // A signal emitted when the current model changes.
+  modelChanged: ISignal<this, IChangedArgs<ICommentFileModel>>;
+
+  // A signal emitted when the panel is revealed.
+  revealed: ISignal<this, undefined>;
+
+  // A signal emitted when a comment widget is added.
+  commentAdded: ISignal<this, CommentWidget>;
+
+  // Scrolls to the comment with id `id`
+  scrollToComment: (id: string) => void;
+
+  // Adds a comment widget and emits the `commentAdded` signal.
+  addCommentWidget: (widget: CommentWidget) => void;
+
+  // An HTMLElement that when clicked opens a comment dialogue.
+  indicator: HTMLElement;
+
+  // The comment factory registry
+  registry: ICommentRegistry;
+
+  // If true, don't change the current model when the current document changes.
+  lockModel: boolean;
+}
+
+/**
+ * An object for creating a comment of a certain type.
+ * T is the type of the target (the thing being commented on)
+ */
+export interface ICommentFactory<T> {
+  // Create a comment based on `options` and the factory configuration.
+  createComment: (options: Exclude<ICommentOptions, 'type'>) => IComment;
+
+  // Serializes a target to be stored in the comment (cell ID, selection start/end, etc)
+  targetToJSON: (target: T) => PartialJSONValue;
+
+  // Finds a target given its serialized representation.
+  JSONToTarget: (target: PartialJSONValue) => T | undefined;
+
+  // Gets the text preview of a target given its serialized representation.
+  // Providing a target of type T and some sort of "fragment object" could
+  // be a better solution here (for example, providing source text and an
+  // object describing a slice)
+  getPreview: (target: PartialJSONValue) => string;
+
+  // The type of comment created by the factory
+  type: string;
+}
+
+// Options object for creating a comment.
+export interface ICommentOptions {
+  text: string;
+  identity: IIdentity;
+  type: string;
+  target: any;
+  replies?: IReply[];
+  id?: string; // defaults to UUID.uuid4()
+}
+
+// Options object for creating a reply.
+export interface IReplyOptions {
+  parentID: string;
+  text: string;
+  identity: IIdentity;
+  id?: string; // defaults to UUID.uuid4()
+}
+
+/**
+ * A type used to represent a changed value.
+ */
+export interface IChangedArgs<T> {
+  name: string;
+  old: T | undefined;
+  new: T | undefined;
+}

--- a/src/commentformat.ts
+++ b/src/commentformat.ts
@@ -1,10 +1,5 @@
-//import { ICellModel } from "@jupyterlab/cells";
 import { CodeEditor } from '@jupyterlab/codeeditor';
-
-/**
- * A type for the 'target' of a comment.
- */
-export type CommentType = 'null' | 'cell' | 'text';
+import { PartialJSONValue } from '@lumino/coreutils';
 
 /**
  * A type for the identity of a commentor.
@@ -21,18 +16,40 @@ export interface IIdentity {
 export interface ISelection extends IComment {
   start: CodeEditor.IPosition;
   end: CodeEditor.IPosition;
-  //source: ICellModel;
-  //content: string;
 }
 
-/**
- * A type for the metadata representation of a comment.
- */
-export type IComment = {
+export interface IBaseComment {
   id: string;
-  type: CommentType;
+  type: string;
   identity: IIdentity;
-  replies: IComment[];
   text: string;
   time: string;
-};
+}
+
+export interface IReply extends IBaseComment {
+  type: 'reply';
+}
+
+export interface ICommentWithReplies extends IBaseComment {
+  replies: IReply[];
+}
+
+export interface IComment extends ICommentWithReplies {
+  target: PartialJSONValue;
+}
+
+export interface ICellComment extends IComment {
+  type: 'cell';
+  target: {
+    cellID: string;
+  };
+}
+
+export interface ICellSelectionComment extends IComment {
+  type: 'cell-selection';
+  target: {
+    cellID: string;
+    start: CodeEditor.IPosition;
+    end: CodeEditor.IPosition;
+  };
+}

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -11,7 +11,6 @@ export interface IMetadated {
 
 export interface ISharedMetadatedText extends ISharedText, IMetadated {}
 
-
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function updateMetadata(model: IMetadated, value: any): void {
   model.setMetadata(Object.assign({}, model.getMetadata(), value));
@@ -153,7 +152,7 @@ function editComment(
 
 export function addReply(
   model: IMetadated,
-  reply: comments.IComment,
+  reply: comments.IReply,
   id: string
 ): void {
   if (reply.text === '') {

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,0 +1,93 @@
+import { IComment, IIdentity, IReply } from './commentformat';
+import { PartialJSONValue, UUID } from '@lumino/coreutils';
+import { getCommentTimeString } from './utils';
+
+export interface ICommentFactory<T = any> {
+  createComment: (options: CommentFactory.ICommentOptions<T>) => IComment;
+  createCommentWithPrecomputedTarget: (
+    options: Exclude<ICommentOptions<T>, 'target'>,
+    target: PartialJSONValue
+  ) => IComment;
+
+  readonly type: string;
+  readonly targetFactory: (target: T) => PartialJSONValue;
+}
+
+/**
+ * A class that creates comments of a given type.
+ */
+export class CommentFactory<T = any> implements ICommentFactory<T> {
+  constructor(options: CommentFactory.IOptions<T>) {
+    const { type, targetFactory } = options;
+
+    this.type = type;
+    this.targetFactory = targetFactory;
+  }
+
+  createComment(options: CommentFactory.ICommentOptions<T>): IComment {
+    const { target, text, identity, replies, id } = options;
+
+    return {
+      text,
+      identity,
+      type: this.type,
+      id: id ?? UUID.uuid4(),
+      replies: replies ?? [],
+      time: getCommentTimeString(),
+      target: this.targetFactory(target)
+    };
+  }
+
+  createCommentWithPrecomputedTarget(
+    options: Exclude<ICommentOptions<T>, 'target'>,
+    target: PartialJSONValue
+  ): IComment {
+    const { text, identity, replies, id } = options;
+
+    return {
+      text,
+      identity,
+      type: this.type,
+      id: id ?? UUID.uuid4(),
+      replies: replies ?? [],
+      time: getCommentTimeString(),
+      target
+    };
+  }
+
+  static createReply(options: IReplyOptions): IReply {
+    const { text, identity, id } = options;
+
+    return {
+      text,
+      identity,
+      id: id ?? UUID.uuid4(),
+      time: getCommentTimeString(),
+      type: 'reply'
+    };
+  }
+
+  readonly type: string;
+  readonly targetFactory: (target: T) => PartialJSONValue;
+}
+
+export namespace CommentFactory {
+  export interface IOptions<T> {
+    type: string;
+    targetFactory: (target: T) => PartialJSONValue;
+  }
+
+  export interface IReplyOptions {
+    text: string;
+    identity: IIdentity;
+    id?: string;
+  }
+
+  export interface ICommentOptions<T> extends IReplyOptions {
+    target: T;
+    replies?: IReply[];
+  }
+}
+
+export type ICommentOptions<T> = CommentFactory.ICommentOptions<T>;
+export type IReplyOptions = CommentFactory.IReplyOptions;

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,0 +1,368 @@
+import { IComment, IIdentity, IReply } from './commentformat';
+import { CommentFactory } from './factory';
+import { ICommentRegistry } from './registry';
+import { YDocument } from '@jupyterlab/shared-models';
+import * as Y from 'yjs';
+import { PartialJSONValue } from '@lumino/coreutils';
+import { ISignal, Signal } from '@lumino/signaling';
+import { Awareness } from 'y-protocols/awareness';
+import { Menu } from '@lumino/widgets';
+
+/**
+ * The default model for comment files.
+ */
+export class CommentFileModel {
+  /**
+   * Construct a new `CommentFileModel`.
+   */
+  constructor(options: CommentFileModel.IOptions) {
+    const { registry, ydoc, awareness, sourcePath, commentMenu } = options;
+
+    this.registry = registry;
+    this.ydoc = ydoc;
+    this.awarenss = awareness;
+    this._sourcePath = sourcePath;
+    this._commentMenu = commentMenu;
+
+    this.comments.observe(this._commentsObserver);
+  }
+
+  /**
+   * Dispose of the model and its resources.
+   */
+  dispose(): void {
+    if (this._isDisposed) {
+      return;
+    }
+
+    this._isDisposed = true;
+    this.comments.unobserve(this._commentsObserver);
+    // Remove all signal connections from the model.
+    Signal.clearData(this);
+  }
+
+  /**
+   * Serialize the model to JSON.
+   */
+  toJSON(): PartialJSONValue {
+    return this.comments.toJSON();
+  }
+
+  /**
+   * Deserialize the model from JSON.
+   */
+  fromJSON(value: PartialJSONValue): void {
+    this.ydoc.transact(() => {
+      const comments = this.comments;
+      comments.delete(0, comments.length);
+      comments.push(value as any as IComment[]);
+    });
+  }
+
+  /**
+   * Serialize the model to a string.
+   */
+  toString(): string {
+    return JSON.stringify(this.toJSON());
+  }
+
+  /**
+   * Deserialize the model from a string.
+   */
+  fromString(value: string): void {
+    this.fromJSON(JSON.parse(value));
+  }
+
+  private _commentsObserver = (event: Y.YArrayEvent<IComment>): void => {
+    // In the future, this should emit a signal describing changes made to the comments.
+    // I don't understand YArrayEvent well enough yet so I'm just logging it here.
+    console.log(event);
+  };
+  /**
+   * Create a comment from an `ICommentOptions` object.
+   *
+   * ### Notes
+   * This will fail if there's no factory for the given comment type.
+   */
+  createComment(options: ICommentOptions): IComment | undefined {
+    const factory = this.registry.getFactory(options.type);
+    if (factory == null) {
+      return;
+    }
+
+    return factory.createComment(options);
+  }
+
+  /**
+   * Create a reply from an `IReplyOptions` object.
+   */
+  createReply(options: Exclude<IReplyOptions, 'parentID'>): IReply {
+    return CommentFactory.createReply(options);
+  }
+
+  /**
+   * Create a comment from `options` and inserts it in `this.comments` at `index`.
+   */
+  insertComment(options: ICommentOptions, index: number): void {
+    const comment = this.createComment(options);
+    if (comment == null) {
+      return;
+    }
+
+    this.comments.insert(index, [comment]);
+  }
+
+  /**
+   * Creates a comment from `options` and inserts it at the end of `this.comments`.
+   */
+  addComment(options: ICommentOptions): void {
+    const comment = this.createComment(options);
+    if (comment == null) {
+      return;
+    }
+
+    this.comments.push([comment]);
+  }
+
+  /**
+   * Creates a reply from `options` and inserts it in the replies of the comment
+   * with id `parentID` at `index`.
+   */
+  insertReply(options: IReplyOptions, parentID: string, index: number): void {
+    const parentComment = this.getComment(parentID);
+    if (parentComment == null) {
+      return;
+    }
+
+    const reply = this.createReply(options);
+    parentComment.replies.splice(index, 0, reply);
+  }
+
+  /**
+   * Creates a reply from `options` and appends it to the replies of the comment
+   * with id `parentID`.
+   */
+  addReply(options: IReplyOptions, parentID: string): void {
+    const parentComment = this.getComment(parentID);
+    if (parentComment == null) {
+      return;
+    }
+
+    const reply = this.createReply(options);
+    parentComment.replies.push(reply);
+  }
+
+  /**
+   * Deletes the comment with id `id` from `this.comments`.
+   */
+  deleteComment(id: string): void {
+    const comments = this.comments;
+    for (let i = 0; i < comments.length; i++) {
+      const comment = comments.get(i);
+      if (comment.id === id) {
+        comments.delete(i);
+        return;
+      }
+    }
+  }
+
+  /**
+   * Deletes the reply with id `id` from `this.comments`.
+   *
+   * If a `parentID` is given, it will be used to locate the parent comment.
+   * Otherwise, all comments will be searched for the reply with the given id.
+   */
+  deleteReply(id: string, parentID?: string): void {
+    if (parentID != null) {
+      const comment = this.getComment(parentID);
+      if (comment == null) {
+        return;
+      }
+
+      const replyIndex = comment.replies.findIndex(reply => reply.id === id);
+      if (replyIndex !== -1) {
+        comment.replies.splice(replyIndex, 1);
+      }
+      return;
+    }
+
+    const comments = this.comments;
+    for (let comment of comments) {
+      const replyIndex = comment.replies.findIndex(reply => reply.id === id);
+      if (replyIndex !== -1) {
+        comment.replies.splice(replyIndex, 1);
+        return;
+      }
+    }
+  }
+
+  /**
+   * Applies the changes in `options` to the comment with id `id`.
+   */
+  editComment(
+    options: Partial<Exclude<ICommentOptions, 'id'>>,
+    id: string
+  ): void {
+    const comment = this.getComment(id);
+    if (comment == null) {
+      return;
+    }
+
+    Object.assign(comment, comment, options);
+  }
+
+  /**
+   * Applies the changes in `options` to the reply with id `id`.
+   *
+   * If a `parentID` is given, it will be used to locate the parent comment.
+   * Otherwise, all comments will be searched for the reply with the given id.
+   */
+  editReply(
+    options: Partial<Exclude<IReplyOptions, 'id'>>,
+    id: string,
+    parentID?: string
+  ): void {
+    const reply = this.getReply(id, parentID);
+    if (reply == null) {
+      return;
+    }
+
+    Object.assign(reply, reply, options);
+  }
+
+  /**
+   * Get the comment with id `id`. Returns undefined if not found.
+   */
+  getComment(id: string): IComment | undefined {
+    const comments = this.comments;
+    for (let comment of comments) {
+      if (comment.id === id) {
+        return comment;
+      }
+    }
+
+    return;
+  }
+
+  /**
+   * The the reply with id `id`. Returns undefined if not found.
+   *
+   * If a `parentID` is given, it will be used to locate the parent comment.
+   * Otherwise, all comments will be searched for the reply with the given id.
+   */
+  getReply(id: string, parentID?: string): IReply | undefined {
+    if (parentID != null) {
+      const comment = this.getComment(parentID);
+      if (comment == null) {
+        return;
+      }
+
+      return comment.replies.find(reply => reply.id === id);
+    }
+
+    const comments = this.comments;
+    for (let comment of comments) {
+      const reply = comment.replies.find(reply => reply.id === id);
+      if (reply != null) {
+        return reply;
+      }
+    }
+
+    return;
+  }
+
+  /**
+   * The comments associated with the model.
+   */
+  get comments(): Y.Array<IComment> {
+    return this.ydoc.ydoc.getArray('comments');
+  }
+
+  /**
+   * Whether the model has been disposed.
+   */
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  /**
+   * The registry containing the comment factories needed to create the model's comments.
+   */
+  readonly registry: ICommentRegistry;
+
+  /**
+   * The underlying model handling RTC between clients.
+   */
+  readonly ydoc: YDocument<any>;
+
+  /**
+   * The awareness associated with the document being commented on.
+   */
+  readonly awarenss: Awareness;
+
+  /**
+   * The path to the document being commented on.
+   */
+  get sourcePath(): string {
+    return this._sourcePath;
+  }
+
+  /**
+   * The dropdown menu for comment widgets.
+   */
+  get commentMenu(): Menu {
+    return this._commentMenu;
+  }
+
+  /**
+   * TODO: A signal emitted when the model is changed.
+   * See the notes on `CommentFileModel.IChange` below.
+   */
+  get changed(): ISignal<this, CommentFileModel.IChange> {
+    return this._changed;
+  }
+
+  private _sourcePath: string;
+  private _commentMenu: Menu;
+  private _isDisposed: boolean = false;
+  private _changed = new Signal<this, CommentFileModel.IChange>(this);
+}
+
+export namespace CommentFileModel {
+  export interface IOptions {
+    registry: ICommentRegistry;
+    ydoc: YDocument<any>;
+    sourcePath: string;
+    awareness: Awareness;
+    commentMenu: Menu;
+  }
+
+  /**
+   * TODO: An interface that describes a change to a model.
+   * This will be filled out once `YArrayEvent` is better understood.
+   */
+  export interface IChange {
+    commentChange: any;
+  }
+}
+
+/**
+ * Options object for creating a comment.
+ */
+export interface ICommentOptions {
+  text: string;
+  identity: IIdentity;
+  type: string;
+  target: any;
+  replies?: IReply[];
+  id?: string; // defaults to UUID.uuid4()
+}
+
+/**
+ * Options object for creating a reply.
+ */
+export interface IReplyOptions {
+  text: string;
+  identity: IIdentity;
+  id?: string; // defaults to UUID.uuid4()
+}

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -14,7 +14,38 @@ import { CommandRegistry } from '@lumino/commands';
 import { Awareness } from 'y-protocols/awareness';
 import { ISelection } from './commentformat';
 
-export class CommentPanel extends Panel {
+export interface ICommentPanel extends Panel {
+  /**
+   * Add a comment widget and emit the `commentAdded` signal.
+   */
+  addComment: (widget: CommentWidget<any>) => void;
+
+  /**
+   * Scroll the comment with the given id into view.
+   */
+  scrollToComment: (id: string) => void;
+
+  /**
+   * A signal emitted when a comment is added to the panel.
+   */
+  commentAdded: Signal<this, CommentWidget<any>>;
+
+  /**
+   * The dropdown menu for comment widgets.
+   */
+  commentMenu: Menu;
+
+  /**
+   * A signal emitted when the panel is about to be shown.
+   */
+  revealed: Signal<this, undefined>;
+
+  awareness: Awareness | undefined;
+
+  nbTracker: INotebookTracker;
+}
+
+export class CommentPanel extends Panel implements ICommentPanel {
   constructor(options: CommentPanel.IOptions) {
     super(options);
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,25 @@
+import { CommentFactory } from './factory';
+
+export interface ICommentRegistry {
+  createFactory: <T>(options: CommentFactory.IOptions<T>) => CommentFactory<T>;
+  getFactory: (id: string) => CommentFactory | undefined;
+
+  readonly factories: Map<string, CommentFactory>;
+}
+
+/**
+ * A class that manages a map of `CommentFactory`s
+ */
+export class CommentRegistry implements ICommentRegistry {
+  createFactory<T>(options: CommentFactory.IOptions<T>): CommentFactory<T> {
+    const factory = new CommentFactory<T>(options);
+    this.factories.set(options.type, factory);
+    return factory;
+  }
+
+  getFactory(id: string): CommentFactory | undefined {
+    return this.factories.get(id);
+  }
+
+  readonly factories = new Map<string, CommentFactory>();
+}


### PR DESCRIPTION
Starts to address Issue #74 

Also includes commits from PR #72 

A default implementation of `ICommentModel`. Implements methods for adding, deleting, editing, and retrieving comments and replies, as well as serializing/deserializing the model.

TODO: Emit a meaningful changed signal when the comments change; initialize the ydoc in the constructor given a source file path.