### PR TITLE
Incremental comment updates and mock comments

### DIFF
--- a/src/button.ts
+++ b/src/button.ts
@@ -30,7 +30,7 @@ export class NewCommentButton extends Widget {
     this.close();
   }
 
-  open(x: number, y: number, f: () => void): void {
+  open(x: number, y: number, f: () => void, anchor?: HTMLElement): void {
     // Bail if button is already attached
     // if (this.isAttached) {
     //   return;
@@ -41,6 +41,14 @@ export class NewCommentButton extends Widget {
     const py = window.pageYOffset;
     const cw = document.documentElement.clientWidth;
     const ch = document.documentElement.clientHeight;
+    let ax = 0;
+    let ay = 0;
+
+    if (anchor != null) {
+      const { left, top } = anchor.getBoundingClientRect();
+      ax = anchor.scrollLeft - left;
+      ay = anchor.scrollTop - top;
+    }
 
     // Reset position
     const style = this.node.style;
@@ -49,7 +57,7 @@ export class NewCommentButton extends Widget {
     style.visibility = 'hidden';
 
     if (!this.isAttached) {
-      Widget.attach(this, document.body);
+      Widget.attach(this, anchor ?? document.body);
     }
 
     const { width, height } = this.node.getBoundingClientRect();
@@ -65,6 +73,10 @@ export class NewCommentButton extends Widget {
         y = y - height;
       }
     }
+
+    // Adjust according to anchor
+    x += ax;
+    y += ay;
 
     // Add onclick function
     this._onClick = f;

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,45 +77,41 @@ const notebookCommentsPlugin: JupyterFrontEndPlugin<void> = {
 
     const button = panel.button;
 
-    function openButton(x: number, y: number): void {
-      button.open(x, y, () => {
-        const cell = nbTracker.activeCell;
-        if (cell == null) {
-          return;
-        }
-
-        const model = panel.model;
-        if (model == null) {
-          return;
-        }
-
-        const comments = model.comments;
-        let index = comments.length;
-        for (let i = comments.length; i > 0; i--) {
-          const comment = comments.get(i - 1) as ICellComment;
-          if (comment.target.cellID === cell.model.id) {
-            index = i;
-          }
-        }
-
-        void InputDialog.getText({ title: 'Add Comment' }).then(value => {
-          if (value.value == null) {
+    function openButton(x: number, y: number, anchor: HTMLElement): void {
+      button.open(
+        x,
+        y,
+        () => {
+          const cell = nbTracker.activeCell;
+          if (cell == null) {
             return;
           }
 
-          model.insertComment(
+          const model = panel.model;
+          if (model == null) {
+            return;
+          }
+
+          const comments = model.comments;
+          let index = comments.length;
+          for (let i = comments.length; i > 0; i--) {
+            const comment = comments.get(i - 1) as ICellComment;
+            if (comment.target.cellID === cell.model.id) {
+              index = i;
+            }
+          }
+
+          panel.mockComment(
             {
+              identity: getIdentity(model.awareness),
               type: 'cell-selection',
-              text: value.value,
-              source: cell,
-              identity: getIdentity(model.awareness)
+              source: cell
             },
             index
           );
-
-          panel.update();
-        });
-      });
+        },
+        anchor
+      );
     }
 
     let currAwareness: Awareness;
@@ -153,8 +149,10 @@ const notebookCommentsPlugin: JupyterFrontEndPlugin<void> = {
 
       // Open add comment button when mouse is released after selection
       onMouseup = (_: MouseEvent): void => {
-        const { right, top, height } = cell.node.getBoundingClientRect();
-        openButton(right - 10, top + height / 2 - 10);
+        const { right, top, height } =
+          cell.editorWidget.node.getBoundingClientRect();
+        const node = nbTracker.currentWidget!.content.node;
+        openButton(right - 10, top + height / 2 - 10, node);
       };
 
       awarenessHandler = (): void => {
@@ -173,30 +171,43 @@ const notebookCommentsPlugin: JupyterFrontEndPlugin<void> = {
     });
 
     app.commands.addCommand(CommandIDs.addNotebookComment, {
-      label: 'Add Cell Comment',
+      label: 'Add Comment',
       execute: () => {
         const cell = nbTracker.activeCell;
         if (cell == null) {
           return;
         }
 
-        void InputDialog.getText({
-          title: 'Enter Comment'
-        }).then(value => {
-          if (value.value == null) {
-            return;
+        const model = panel.model;
+        if (model == null) {
+          return;
+        }
+
+        const comments = model.comments;
+        let index = comments.length;
+        for (let i = comments.length; i > 0; i--) {
+          const comment = comments.get(i - 1) as ICellComment;
+          if (comment.target.cellID === cell.model.id) {
+            index = i;
           }
+        }
 
-          const model = panel.model!;
-          model.addComment({
-            source: cell,
-            text: value.value,
+        let type;
+        const { start, end } = cell.editor.getSelection();
+        if (start.column === end.column && start.line === end.line) {
+          type = 'cell';
+        } else {
+          type = 'cell-selection';
+        }
+
+        panel.mockComment(
+          {
             identity: getIdentity(model.awareness),
-            type: 'cell'
-          });
-
-          panel.update();
-        });
+            type,
+            source: cell
+          },
+          index
+        );
       }
     });
 
@@ -285,8 +296,15 @@ export const jupyterCommentingPlugin: JupyterFrontEndPlugin<ICommentPanel> = {
       }
     });
 
+    commentTracker.widgetAdded.connect((_, widget) =>
+      console.log('widget tracked', widget)
+    );
+
     panel.modelChanged.connect((_, fileWidget) => {
       if (fileWidget != null) {
+        fileWidget.widgets.forEach(
+          widget => void commentTracker.add(widget as CommentWidget<any>)
+        );
         fileWidget.commentAdded.connect(
           (_, commentWidget) => void commentTracker.add(commentWidget)
         );
@@ -372,8 +390,6 @@ function addCommands(
           }
 
           model.addComment(comment);
-
-          panel.update();
         }
       });
     }
@@ -385,7 +401,6 @@ function addCommands(
       const currentComment = commentTracker.currentWidget;
       if (currentComment != null) {
         currentComment.deleteActive();
-        panel.update();
       }
     }
   });

--- a/src/model.ts
+++ b/src/model.ts
@@ -38,6 +38,7 @@ export class CommentFileModel implements DocumentRegistry.IModel {
     }
 
     this._isDisposed = true;
+    console.log('disposed old model');
     this.comments.unobserveDeep(this._commentsObserver);
   }
 
@@ -75,11 +76,33 @@ export class CommentFileModel implements DocumentRegistry.IModel {
     this.fromJSON(JSON.parse(value !== '' ? value : '[]'));
   }
 
-  private _commentsObserver = (event: Y.YEvent[]): void => {
-    // In the future, this should emit a signal describing changes made to the comments.
-    // I don't understand YArrayEvent well enough yet so I'm just logging it here.
-    console.log('changes', event as Y.YEvent[]);
+  private _commentsObserver = (events: Y.YEvent[]): void => {
+    console.log('comment change');
+    // const f = (_: this, e: CommentFileModel.IChange[]): void => console.log('delta', e);
+    for (let event of events) {
+      // this.changed.connect(f);
+      this._changed.emit(event.delta as any);
+      // this.changed.disconnect(f);
+    }
   };
+
+  // private _emitUpdate(index: number): void {
+  //   this._changed.emit([
+  //     { retain: index },
+  //     { update: 1 }
+  //   ]);
+
+  //   this._contentChanged.emit();
+  // }
+
+  private _updateComment(comment: IComment, index: number): void {
+    const comments = this.comments;
+    this.ymodel.ydoc.transact(() => {
+      comments.delete(index);
+      comments.insert(index, [comment]);
+    });
+    this._contentChanged.emit();
+  }
 
   /**
    * Create a comment from an `ICommentOptions` object.
@@ -117,6 +140,7 @@ export class CommentFileModel implements DocumentRegistry.IModel {
     }
 
     this.comments.insert(index, [comment]);
+    // Delta emitted by listener
     this._contentChanged.emit();
   }
 
@@ -130,6 +154,7 @@ export class CommentFileModel implements DocumentRegistry.IModel {
     }
 
     this.comments.push([comment]);
+    // Delta emitted by listener
     this._contentChanged.emit();
   }
 
@@ -138,14 +163,15 @@ export class CommentFileModel implements DocumentRegistry.IModel {
    * with id `parentID` at `index`.
    */
   insertReply(options: IReplyOptions, parentID: string, index: number): void {
-    const parentComment = this.getComment(parentID);
-    if (parentComment == null) {
+    const loc = this.getComment(parentID);
+    if (loc == null) {
       return;
     }
 
     const reply = this.createReply(options);
-    parentComment.replies.splice(index, 0, reply);
-    this._contentChanged.emit();
+    const newComment = { ...loc.comment };
+    newComment.replies.splice(index, 0, reply);
+    this._updateComment(newComment, loc.index);
   }
 
   /**
@@ -153,29 +179,29 @@ export class CommentFileModel implements DocumentRegistry.IModel {
    * with id `parentID`.
    */
   addReply(options: IReplyOptions, parentID: string): void {
-    const parentComment = this.getComment(parentID);
-    if (parentComment == null) {
+    const loc = this.getComment(parentID);
+    if (loc == null) {
       return;
     }
 
     const reply = this.createReply(options);
-    parentComment.replies.push(reply);
-    this._contentChanged.emit();
+    const newComment = { ...loc.comment };
+    newComment.replies.push(reply);
+    this._updateComment(newComment, loc.index);
   }
 
   /**
    * Deletes the comment with id `id` from `this.comments`.
    */
   deleteComment(id: string): void {
-    const comments = this.comments;
-    for (let i = 0; i < comments.length; i++) {
-      const comment = comments.get(i);
-      if (comment.id === id) {
-        comments.delete(i);
-        this._contentChanged.emit();
-        return;
-      }
+    const loc = this.getComment(id);
+    if (loc == null) {
+      return;
     }
+
+    this.comments.delete(loc.index);
+    // Delta emitted by listener
+    this._contentChanged.emit();
   }
 
   /**
@@ -185,29 +211,14 @@ export class CommentFileModel implements DocumentRegistry.IModel {
    * Otherwise, all comments will be searched for the reply with the given id.
    */
   deleteReply(id: string, parentID?: string): void {
-    if (parentID != null) {
-      const comment = this.getComment(parentID);
-      if (comment == null) {
-        return;
-      }
-
-      const replyIndex = comment.replies.findIndex(reply => reply.id === id);
-      if (replyIndex !== -1) {
-        comment.replies.splice(replyIndex, 1);
-        this._contentChanged.emit();
-      }
+    const loc = this.getReply(id, parentID);
+    if (loc == null) {
       return;
     }
 
-    const comments = this.comments;
-    for (let comment of comments) {
-      const replyIndex = comment.replies.findIndex(reply => reply.id === id);
-      if (replyIndex !== -1) {
-        comment.replies.splice(replyIndex, 1);
-        this._contentChanged.emit();
-        return;
-      }
-    }
+    const newComment = { ...loc.parent };
+    newComment.replies.splice(loc.index, 1);
+    this._updateComment(newComment, loc.parentIndex);
   }
 
   /**
@@ -217,13 +228,13 @@ export class CommentFileModel implements DocumentRegistry.IModel {
     options: Partial<Exclude<ICommentOptions, 'id'>>,
     id: string
   ): void {
-    const comment = this.getComment(id);
-    if (comment == null) {
+    const loc = this.getComment(id);
+    if (loc == null) {
       return;
     }
 
-    Object.assign(comment, comment, options);
-    this._contentChanged.emit();
+    const newComment = { ...loc.comment, ...options };
+    this._updateComment(newComment, loc.index);
   }
 
   /**
@@ -237,23 +248,28 @@ export class CommentFileModel implements DocumentRegistry.IModel {
     id: string,
     parentID?: string
   ): void {
-    const reply = this.getReply(id, parentID);
-    if (reply == null) {
+    const loc = this.getReply(id, parentID);
+    if (loc == null) {
       return;
     }
 
-    Object.assign(reply, reply, options);
-    this._contentChanged.emit();
+    Object.assign(loc.reply, loc.reply, options);
+    const newComment = { ...loc.parent };
+    this._updateComment(newComment, loc.parentIndex);
   }
 
   /**
    * Get the comment with id `id`. Returns undefined if not found.
    */
-  getComment(id: string): IComment | undefined {
+  getComment(id: string): CommentFileModel.ICommentLocation | undefined {
     const comments = this.comments;
-    for (let comment of comments) {
+    for (let i = 0; i < comments.length; i++) {
+      const comment = comments.get(i);
       if (comment.id === id) {
-        return comment;
+        return {
+          index: i,
+          comment
+        };
       }
     }
 
@@ -261,26 +277,55 @@ export class CommentFileModel implements DocumentRegistry.IModel {
   }
 
   /**
-   * The the reply with id `id`. Returns undefined if not found.
+   * Returns the reply with id `id`. Returns undefined if not found.
    *
    * If a `parentID` is given, it will be used to locate the parent comment.
    * Otherwise, all comments will be searched for the reply with the given id.
    */
-  getReply(id: string, parentID?: string): IReply | undefined {
+  getReply(
+    id: string,
+    parentID?: string
+  ): CommentFileModel.IReplyLocation | undefined {
+    let parentIndex: number;
+    let parent: IComment;
+
     if (parentID != null) {
-      const comment = this.getComment(parentID);
-      if (comment == null) {
+      const parentLocation = this.getComment(parentID);
+      if (parentLocation == null) {
         return;
       }
 
-      return comment.replies.find(reply => reply.id === id);
+      parentIndex = parentLocation.index;
+      parent = parentLocation.comment;
+
+      for (let i = 0; i < parent.replies.length; i++) {
+        const reply = parent.replies[i];
+        if (reply.id === id) {
+          return {
+            parentIndex,
+            parent,
+            reply,
+            index: i
+          };
+        }
+      }
+
+      return;
     }
 
     const comments = this.comments;
-    for (let comment of comments) {
-      const reply = comment.replies.find(reply => reply.id === id);
-      if (reply != null) {
-        return reply;
+    for (let i = 0; i < comments.length; i++) {
+      const parent = comments.get(i);
+      for (let j = 0; i < parent.replies.length; i++) {
+        const reply = parent.replies[j];
+        if (reply.id === id) {
+          return {
+            parentIndex: i,
+            parent,
+            reply,
+            index: j
+          };
+        }
       }
     }
 
@@ -327,7 +372,7 @@ export class CommentFileModel implements DocumentRegistry.IModel {
    * TODO: A signal emitted when the model is changed.
    * See the notes on `CommentFileModel.IChange` below.
    */
-  get changed(): ISignal<this, CommentFileModel.IChange> {
+  get changed(): ISignal<this, CommentFileModel.IChange[]> {
     return this._changed;
   }
 
@@ -391,7 +436,7 @@ export class CommentFileModel implements DocumentRegistry.IModel {
   private _readOnly: boolean = false;
   private _isDisposed: boolean = false;
   private _commentMenu: Menu | undefined;
-  private _changed = new Signal<this, CommentFileModel.IChange>(this);
+  private _changed = new Signal<this, CommentFileModel.IChange[]>(this);
   private _stateChanged = new Signal<this, IChangedArgs<any>>(this);
   private _contentChanged = new Signal<this, void>(this);
 }
@@ -408,7 +453,22 @@ export namespace CommentFileModel {
    * This will be filled out once `YArrayEvent` is better understood.
    */
   export interface IChange {
-    commentChange: any;
+    insert?: IComment[];
+    retain?: number;
+    delete?: number;
+    update?: number;
+  }
+
+  export interface ICommentLocation {
+    index: number;
+    comment: IComment;
+  }
+
+  export interface IReplyLocation {
+    parentIndex: number;
+    index: number;
+    parent: IComment;
+    reply: IReply;
   }
 }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -38,7 +38,6 @@ export class CommentFileModel implements DocumentRegistry.IModel {
     }
 
     this._isDisposed = true;
-    console.log('disposed old model');
     this.comments.unobserveDeep(this._commentsObserver);
   }
 
@@ -77,12 +76,8 @@ export class CommentFileModel implements DocumentRegistry.IModel {
   }
 
   private _commentsObserver = (events: Y.YEvent[]): void => {
-    console.log('comment change');
-    // const f = (_: this, e: CommentFileModel.IChange[]): void => console.log('delta', e);
     for (let event of events) {
-      // this.changed.connect(f);
       this._changed.emit(event.delta as any);
-      // this.changed.disconnect(f);
     }
   };
 

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -89,9 +89,7 @@ export class CommentPanel extends Panel implements ICommentPanel {
   }
 
   onUpdateRequest(msg: Message): void {
-    console.log('panel update request');
     if (this._fileWidget == null) {
-      console.log('this._fileWidget is null');
       return;
     }
 

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -848,7 +848,6 @@ export class CommentFileWidget extends Panel {
     if (widget != null) {
       this.insertWidget(index, widget);
       this._commentAdded.emit(widget);
-      console.log('insertComment', widget);
     }
   }
 
@@ -873,7 +872,6 @@ export class CommentFileWidget extends Panel {
     if (widget != null) {
       this.addWidget(widget);
       this._commentAdded.emit(widget);
-      console.log('addComment', widget);
     }
   }
 


### PR DESCRIPTION
Before, every change to a comment widget would involve disposing of and re-creating every comment widget in the panel. This was inefficient and I believed it was causing an issue with rendering text selections. Unfortunately, this did not fix the text selection issue, but it did make rendering comments faster.

## Code changes
- Incremental re-rendering of comments.
- Fixed bug where "+ comment" button wouldn't move when scrolling.
- Mock comment widget.
- Comment model emits a `changed` signal with the change delta.
- `getComment` and `getReply` methods of the model return an object with the target and the target's index.

## User-facing changes
- Adding a comment now opens an empty "mock comment" in the comment panel that the user fills in. This replaces the previous pop-up dialogue.

![github_better_add](https://user-images.githubusercontent.com/38936057/128089614-dbbc8840-0a77-4314-93d8-2c6276d965de.gif)