### PR TITLE
change comment file name when source file renamed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -307,7 +307,7 @@ export const jupyterCommentingPlugin: JupyterFrontEndPlugin<ICommentPanel> = {
     shell.currentChanged.connect((_, args) => {
       if (args.newValue != null && args.newValue instanceof DocumentWidget) {
         const docWidget = args.newValue as DocumentWidget;
-        void panel.loadModel(docWidget.context.path);
+        void panel.loadModel(docWidget.context);
       }
     });
 


### PR DESCRIPTION
Ugly pre-demo patch to prevent comments breaking when the source file is renamed or moved. Doesn't cause the name to update in the panel header but fine for now.