### PR TITLE
Notebook button bug fix

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -187,8 +187,8 @@ export class CellSelectionCommentFactory extends ACommentFactory<Cell> {
     widget.disposed.connect(() => {
       const tempSels = selectionsMap.get(cell.model.id);
       let sels: CodeEditor.ITextSelection[] = [];
-      if(tempSels != null) {
-        sels = JSON.parse(JSON.stringify(tempSels))
+      if (tempSels != null) {
+        sels = JSON.parse(JSON.stringify(tempSels));
       }
       const newSels = sels.filter(sel => sel.uuid !== comment.id);
       selectionsMap.set(cell.model.id, newSels);
@@ -337,12 +337,11 @@ export class TextSelectionCommentFactory extends ACommentFactory<CodeEditorWrapp
 
     widget.disposed.connect(() => {
       console.warn('disposing');
-      const tempSels =
-        selectionsMap.get(
-          (wrapper.parent as DocumentWidget)?.context.path
-        );
-      let sels : CodeEditor.ITextSelection[] = [];
-      if(tempSels != null) {
+      const tempSels = selectionsMap.get(
+        (wrapper.parent as DocumentWidget)?.context.path
+      );
+      let sels: CodeEditor.ITextSelection[] = [];
+      if (tempSels != null) {
         sels = JSON.parse(JSON.stringify(tempSels));
       }
       const newSels = sels.filter(sel => sel.uuid !== comment.id);

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -64,14 +64,14 @@ export interface ICommentPanel extends Panel {
 export class CommentPanel extends Panel implements ICommentPanel {
   renderer: IRenderMimeRegistry;
 
-  constructor(options: CommentPanel.IOptions, renderer: IRenderMimeRegistry) {
+  constructor(options: CommentPanel.IOptions) {
     super();
 
     this.id = `CommentPanel-${UUID.uuid4()}`;
     this.title.icon = CommentsPanelIcon;
     this.addClass('jc-CommentPanel');
 
-    const { docManager, registry, shell } = options;
+    const { docManager, registry, shell, renderer } = options;
 
     this._registry = registry;
     this._commentMenu = new Menu({ commands: options.commands });
@@ -366,6 +366,7 @@ export class CommentPanel extends Panel implements ICommentPanel {
     });
 
     this.fileWidget!.insertWidget(index, widget);
+    this._commentAdded.emit(widget);
   }
 
   updateIdentity(id: number, newName: string): void {
@@ -434,5 +435,6 @@ export namespace CommentPanel {
     commands: CommandRegistry;
     registry: ICommentRegistry;
     shell: ILabShell;
+    renderer: IRenderMimeRegistry;
   }
 }

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -100,7 +100,7 @@ function JCComment(props: CommentProps): JSX.Element {
 
   return (
     <Jdiv
-      className={'jc-Comment ' + className}
+      className={'jc-Comment jc-mod-focus-border' + className}
       id={comment.id}
       jcEventArea="other"
     >
@@ -152,7 +152,7 @@ function JCReply(props: ReplyProps): JSX.Element {
 
   return (
     <Jdiv
-      className={'jc-Comment jc-Reply ' + className}
+      className={'jc-Comment jc-Reply jc-mod-focus-border' + className}
       id={reply.id}
       jcEventArea="other"
     >
@@ -215,13 +215,16 @@ function JCCommentWithReplies(props: CommentWithRepliesProps): JSX.Element {
     } else {
       return (
         <div className={'jc-Replies'}>
-          <Jdiv className="jc-Replies-breaker" jcEventArea="collapser">
+          <Jdiv
+            className="jc-Replies-breaker jc-mod-focus-border"
+            jcEventArea="collapser"
+          >
             <div className="jc-Replies-breaker-left">expand thread</div>
             <div className="jc-RepliesSpacer" />
             <div className="jc-Replies-breaker-right">
               <hr />
               <hr />
-              <div className="jc-Replies-breaker-number">
+              <div className="jc-Replies-breaker-number jc-mod-focus-border">
                 {comment.replies.length - 1}
               </div>
             </div>
@@ -256,7 +259,7 @@ function JCReplyArea(props: ReplyAreaProps): JSX.Element {
 
   return (
     <Jdiv
-      className={'jc-ReplyInputArea ' + className}
+      className={'jc-ReplyInputArea jc-mod-focus-border' + className}
       contentEditable={true}
       hidden={hidden}
       jcEventArea="reply"

--- a/style/base.css
+++ b/style/base.css
@@ -2,7 +2,6 @@
   --jc-dropdown-size: 25px;
 
   --jc-comment-profile-pic-size: 32px;
-  --jc-reply-profile-pic-size: 26px;
 
   --jc-reply-pic-size: 24px;
 
@@ -17,8 +16,8 @@
   --jc-timestamp-font-size: smaller;
   --jc-timestamp-font-weight: regular;
 
-  --jc-nametag-font-size: normal;
-  --jc-nametag-font-weight: 500;
+  --jc-nametag-font-size: var(--jp-ui-font-size1);
+  --jc-nametag-font-weight: 450;
 
   --var-jc-linesep: 2px;
 }
@@ -56,6 +55,7 @@
 }
 
 .jc-Body {
+  font-size: 0.833rem;
   outline: none;
   border: none;
   appearance: none;
@@ -65,7 +65,7 @@
   white-space: pre-wrap;
   margin-top: var(--var-jc-linesep);
   line-height: 1.2em;
-  padding: 3px;
+  padding: 3px 1px;
 }
 
 .jc-Body strong {
@@ -98,9 +98,13 @@
   z-index: 2;
   border-top: var(--jc-comment-border);
   position: relative;
+  cursor: pointer;
 }
 
-.jc-CommentWidget:focus-within .jc-Replies-breaker {
+.jc-CommentWidget:focus-within .jc-mod-focus-border {
+  border-color: var(--jp-brand-color1);
+}
+.jc-CommentWidget:focus-within {
   border-color: var(--jp-brand-color1);
 }
 
@@ -206,17 +210,6 @@
   border-radius: 5px;
 }
 
-.jc-CommentWidget:focus-within {
-  border-color: var(--jp-brand-color1);
-}
-
-.jc-CommentWidget:focus-within .jc-Comment {
-  border-color: var(--jp-brand-color1);
-}
-.jc-CommentWidget:focus-within .jc-ReplyInputArea {
-  border-color: var(--jp-brand-color1);
-}
-
 .jc-ReplyInputArea:empty:before {
   content: attr(data-placeholder);
   color: var(--jp-ui-font-color3);
@@ -281,6 +274,7 @@
   font-size: var(--jp-ui-font-size0);
   display: flex;
   justify-content: start;
+  font-size: var(--jp-ui-font-size0);
 }
 .jc-panelHeader-editIcon {
   transform: scale(0.72);


### PR DESCRIPTION
Addresses Issue #115

Highlighting text in a notebook now causes the "+ comment" button to appear as expected. The button also appears aligned with the vertical middle of the text selection as it does for text files.

Adding a comment also reveals the side panel and scrolls to the mock comment as intended.

In addition, this PR introduces some small styling changes.
- Cursor is now the "pointer" cursor when hovering over the comment expander.
- Comment expander circle border is blue when comment is focused.
- Slight horizontal margin decrease for body text.
- Slight comment body text size decrease.
- Comment nametag is now less slightly less bold.