### PR TITLE
Fix chin bug from markdown rendering in comments and replies

### DIFF
--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -426,6 +426,7 @@ export class CommentWidget<T> extends ReactWidget implements ICommentWidget<T> {
       this.node.focus();
     }
 
+    // this.editID = ""
     this._collapseOtherComments();
   }
 
@@ -484,7 +485,7 @@ export class CommentWidget<T> extends ReactWidget implements ICommentWidget<T> {
    */
   protected _handleBodyClick(event: React.MouseEvent): void {
     this._setClickFocus(event);
-    this.openEditActive();
+    // this.openEditActive();
   }
 
   /**
@@ -531,6 +532,8 @@ export class CommentWidget<T> extends ReactWidget implements ICommentWidget<T> {
       },
       this.commentID
     );
+
+    // this.editID = ''
 
     target.textContent = '';
     this.replyAreaHidden = true;
@@ -782,9 +785,7 @@ export namespace CommentWidget {
   export interface IOptions<T> {
     id: string;
     model: CommentFileModel;
-
     target: T;
-
     factory: ACommentFactory;
   }
 

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -93,15 +93,38 @@ function JCPreview(props: PreviewProps): JSX.Element {
   );
 }
 
-/**
- * A React component that renders a single comment or reply.
- *
- * @param comment - the comment object to render. Note: Replies will
- * not be rendered.
- *
- * @param className - a string that will be used as the className of the
- * container element.
- */
+function JMarkdownRenderer(props: JMarkdownRendererProps): JSX.Element {
+  const { registry, commentWidget, text } = props;
+  let node: HTMLElement = document.createElement('div');
+  const [renderElement, SetRenderElement] = React.useState(<div></div>);
+
+  React.useEffect(() => {
+    const markdownRender = async () => {
+      void renderMarkdown({
+        host: node as HTMLElement,
+        source: text,
+        trusted: false,
+        latexTypesetter: registry.latexTypesetter,
+        linkHandler: registry.linkHandler,
+        resolver: registry.resolver,
+        sanitizer: registry.sanitizer,
+        shouldTypeset: commentWidget.isAttached
+      }).then(() => {
+        SetRenderElement(
+          <div
+            className="jc-MarkdownBody"
+            dangerouslySetInnerHTML={{
+              __html: (node as HTMLElement).innerHTML
+            }}
+          ></div>
+        );
+      });
+    };
+    void markdownRender();
+  }, []);
+  return renderElement;
+}
+
 function JCComment(props: CommentProps): JSX.Element {
   const comment = props.comment;
   const className = props.className || '';
@@ -152,7 +175,7 @@ function JCComment(props: CommentProps): JSX.Element {
           document.execCommand('selectAll', false, undefined);
         }}
       >
-       <JMarkdownRenderer
+        <JMarkdownRenderer
           text={comment.text}
           registry={renderer}
           commentWidget={commentWidget}
@@ -160,38 +183,6 @@ function JCComment(props: CommentProps): JSX.Element {
       </Jdiv>
     </Jdiv>
   );
-}
-
-function JMarkdownRenderer(props: JMarkdownRendererProps): JSX.Element {
-  const { registry, commentWidget, text } = props;
-  let node: HTMLElement = document.createElement('div');
-  const [renderElement, SetRenderElement] = React.useState(<div></div>);
-
-  React.useEffect(() => {
-    const markdownRender = async () => {
-      void renderMarkdown({
-        host: node as HTMLElement,
-        source: text,
-        trusted: false,
-        latexTypesetter: registry.latexTypesetter,
-        linkHandler: registry.linkHandler,
-        resolver: registry.resolver,
-        sanitizer: registry.sanitizer,
-        shouldTypeset: commentWidget.isAttached
-      }).then(() => {
-        SetRenderElement(
-          <div
-            className="jc-MarkdownBody"
-            dangerouslySetInnerHTML={{
-              __html: (node as HTMLElement).innerHTML
-            }}
-          ></div>
-        );
-      });
-    };
-    void markdownRender();
-  }, []);
-  return renderElement;
 }
 
 function JCReply(props: ReplyProps): JSX.Element {

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -121,13 +121,13 @@ function ReactMarkdownRenderer(props: ReactMarkdownRendererProps): JSX.Element {
     const markdownRender = async () => {
       await renderMarkdown({
         host: node as HTMLElement,
-        source: source,
         trusted: false,
-        latexTypesetter: latexTypesetter,
-        linkHandler: linkHandler,
-        resolver: resolver,
-        sanitizer: sanitizer,
-        shouldTypeset: shouldTypeset
+        source,
+        latexTypesetter,
+        linkHandler,
+        resolver,
+        sanitizer,
+        shouldTypeset
       });
       SetRenderElement(
         <div

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -181,7 +181,7 @@ function JMarkdownRenderer(props: JMarkdownRendererProps): JSX.Element {
       }).then(() => {
         SetRenderElement(
           <div
-            className="jc-customBody"
+            className="jc-MarkdownBody"
             dangerouslySetInnerHTML={{
               __html: (node as HTMLElement).innerHTML
             }}
@@ -1038,7 +1038,6 @@ export class CommentFileWidget extends Panel {
 
     if (widget != null) {
       this.insertWidget(index, widget);
-      // this.render_all(widget, this.renderer);
       this._commentAdded.emit(widget);
     }
   }
@@ -1053,28 +1052,6 @@ export class CommentFileWidget extends Panel {
 
   addComment(comment: IComment) {
     this.insertComment(comment, this.widgets.length);
-  }
-
-  /**
-   * Render markdown and LaTeX in a comment widget
-   */
-  render_all(widget: CommentWidget<any>, registry: IRenderMimeRegistry): void {
-    let nodes = widget.node.getElementsByClassName('jc-Body');
-
-    Array.from(nodes).forEach(element => {
-      // (element as HTMLElement).className = 'jc-customBody';
-      (element as HTMLElement).classList.add('jc-customBody');
-      renderMarkdown({
-        host: element as HTMLElement,
-        source: (element as HTMLElement).innerText,
-        trusted: false,
-        latexTypesetter: registry.latexTypesetter,
-        linkHandler: registry.linkHandler,
-        resolver: registry.resolver,
-        sanitizer: registry.sanitizer,
-        shouldTypeset: widget.isAttached
-      }).catch(() => console.warn('render Markdown failed'));
-    });
   }
 
   get model(): CommentFileModel {

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -240,7 +240,6 @@ function JCCommentWithReplies(props: CommentWithRepliesProps): JSX.Element {
   };
 
   return (
-    // <Jdiv className={'jc-CommentWithReplies ' + className} onFocus={() => document.execCommand('selectAll', false, undefined)}>
     <Jdiv className={'jc-CommentWithReplies ' + className}>
       <JCComment
         comment={comment}
@@ -991,10 +990,11 @@ export class CommentFileWidget extends Panel {
     let nodes = widget.node.getElementsByClassName('jc-Body');
 
     Array.from(nodes).forEach(element => {
+      (element as HTMLElement).className = 'jc-customBody';
       renderMarkdown({
         host: element as HTMLElement,
         source: (element as HTMLElement).innerText,
-        trusted: true,
+        trusted: false,
         latexTypesetter: registry.latexTypesetter,
         linkHandler: registry.linkHandler,
         resolver: registry.resolver,

--- a/style/base.css
+++ b/style/base.css
@@ -55,13 +55,13 @@
 }
 
 /* comment */
-.jc-customBody {
+.jc-MarkdownBody {
   margin: 0;
   padding: 0;
 } 
 
 /* replies */
-.jc-customBody > *{
+.jc-MarkdownBody > *{
   display: inline-block;
   margin: 0;
   padding: 0;

--- a/style/base.css
+++ b/style/base.css
@@ -54,13 +54,27 @@
   margin-left: 10px;
 }
 
+/* comment */
+.jc-customBody {
+  display: inline-block;
+  margin: 0;
+  padding: 0;
+} 
+
+/* replies */
+.jc-customBody > *{
+  display: inline-block;
+  margin: 0;
+  padding: 0;
+}
+
 .jc-Body {
   font-size: 0.833rem;
   outline: none;
   border: none;
-  appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
+  /* appearance: none; */
+  /* -webkit-appearance: none; */
+  /* -moz-appearance: none; */
   background-color: transparent;
   white-space: pre-wrap;
   margin-top: var(--var-jc-linesep);

--- a/style/base.css
+++ b/style/base.css
@@ -56,7 +56,7 @@
 
 /* comment */
 .jc-customBody {
-  display: inline-block;
+  /* display: inline-block; */
   margin: 0;
   padding: 0;
 } 

--- a/style/base.css
+++ b/style/base.css
@@ -56,7 +56,6 @@
 
 /* comment */
 .jc-customBody {
-  /* display: inline-block; */
   margin: 0;
   padding: 0;
 } 


### PR DESCRIPTION
Addressed the issue #104 by adding in a custom CSS selector. Also changed the flow of rendering to happen every single time the comment/reply gets rendered in `JCComment` and `JCReply` to fix a bug where the reply's formatting disappears when its comment widget gets focus.
