### PR TITLE
added save/refresh buttons to comment panel header

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -58,7 +58,7 @@ export class CommentFileModel implements DocumentRegistry.IModel {
       comments.push(value as any as IComment[]);
     });
 
-    this._contentChanged.emit();
+    this._signalContentChange();
   }
 
   /**
@@ -109,7 +109,7 @@ export class CommentFileModel implements DocumentRegistry.IModel {
       comments.delete(index);
       comments.insert(index, [comment]);
     });
-    this._contentChanged.emit();
+    this._signalContentChange();
   }
 
   /**
@@ -149,7 +149,7 @@ export class CommentFileModel implements DocumentRegistry.IModel {
 
     this.comments.insert(index, [comment]);
     // Delta emitted by listener
-    this._contentChanged.emit();
+    this._signalContentChange();
   }
 
   /**
@@ -163,7 +163,7 @@ export class CommentFileModel implements DocumentRegistry.IModel {
 
     this.comments.push([comment]);
     // Delta emitted by listener
-    this._contentChanged.emit();
+    this._signalContentChange();
   }
 
   /**
@@ -209,7 +209,7 @@ export class CommentFileModel implements DocumentRegistry.IModel {
 
     this.comments.delete(loc.index);
     // Delta emitted by listener
-    this._contentChanged.emit();
+    this._signalContentChange();
   }
 
   /**
@@ -432,6 +432,11 @@ export class CommentFileModel implements DocumentRegistry.IModel {
       newValue,
       name
     });
+  }
+
+  private _signalContentChange(): void {
+    this.dirty = true;
+    this._contentChanged.emit();
   }
 
   // These are never used--just here to satisfy the interface requirements.

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -150,6 +150,8 @@ export class CommentPanel extends Panel implements ICommentPanel {
       return;
     }
 
+    this._sourcePath = newPath;
+
     void commentContext
       .rename(hashString(newPath).toString() + '.comment')
       .then(() => void commentContext.save());
@@ -167,6 +169,8 @@ export class CommentPanel extends Panel implements ICommentPanel {
     if (sourcePath === '') {
       return;
     }
+
+    this._sourcePath = sourcePath;
 
     this._loadingModel = true;
 
@@ -333,6 +337,10 @@ export class CommentPanel extends Panel implements ICommentPanel {
     this._pathPrefix = newValue;
   }
 
+  get sourcePath(): string | null {
+    return this._sourcePath;
+  }
+
   mockComment(
     options: CommentFileWidget.IMockCommentOptions,
     index: number
@@ -427,6 +435,7 @@ export class CommentPanel extends Panel implements ICommentPanel {
     changes: CommentFileModel.IChange[]
   ) => void;
   private _localIdentity: IIdentity;
+  private _sourcePath: string | null = null;
 }
 
 export namespace CommentPanel {

--- a/style/base.css
+++ b/style/base.css
@@ -350,3 +350,12 @@
   width: 120px;
   background-color: red;
 }
+
+.jc-DirtyIndicator {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--jp-ui-font-color2);
+  margin-left: 8px;
+}

--- a/style/base.css
+++ b/style/base.css
@@ -338,6 +338,13 @@
   height: 80%;
 }
 
+.jc-Button {
+  cursor: pointer;
+}
+.jc-Button > svg {
+  width: 20px;
+}
+
 .jc-Error {
   height: 120px;
   width: 120px;


### PR DESCRIPTION
Addresses issue #126 

Removes the unused dummy buttons on the comment panel and adds working save and refresh buttons. Also adds the path to the comment file on mouseover of the source file title.

Still needs some sort of visual feedback that the save button was pressed--maybe a dot in the panel that indicates the "dirty" status that's cleared by a save?

<img width="257" alt="image" src="https://user-images.githubusercontent.com/38936057/129778308-ee671e05-bd86-4d01-b390-474f38fc17ee.png">

EDIT: Added dirty indicator.
![dirty_status](https://user-images.githubusercontent.com/38936057/129807282-79f94050-3700-4f61-8e69-774af7d5f9de.gif)

