### PR TITLE
Relative selections + other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ![Github Actions Status](https://github.com/jupytercalpoly/jupyterlab-comments/workflows/Build/badge.svg)[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupytercalpoly/jupyterlab-comments/main?urlpath=lab)
 
-Chat and comment in JupyterLab.
+Comment on files and notebooks in JupyterLab
 
 Extension is currently pre-alpha status.
 
 ## Requirements
 
-- JupyterLab >= 3.1.0b0
+- JupyterLab >= 3.1.3
 
 ## Contributing
 

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,10 +1,8 @@
 import {
   ICellSelectionComment,
-  // ICellSelectionComment,
   IComment,
   IIdentity,
   IReply,
-  ISelection,
   ITextSelectionComment
 } from './commentformat';
 import { WidgetTracker } from '@jupyterlab/apputils';
@@ -15,7 +13,6 @@ import { CommentFileModel } from './model';
 import { CommentWidget } from './widget';
 import { INotebookTracker } from '@jupyterlab/notebook';
 import { CodeEditor, CodeEditorWrapper } from '@jupyterlab/codeeditor';
-import { DocumentWidget } from '@jupyterlab/docregistry';
 import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 import * as CodeMirror from 'codemirror';
 
@@ -36,7 +33,7 @@ export abstract class ACommentFactory<T = any> {
     return comment as unknown as PartialJSONObject;
   }
 
-  getElement(target: T): HTMLElement | undefined {
+  getElement(comment: IComment, target?: T): HTMLElement | undefined {
     return;
   }
 
@@ -131,8 +128,8 @@ export class CellCommentFactory extends ACommentFactory<Cell> {
     return notebook.content.widgets.find(w => w.model.id === cellID);
   }
 
-  getElement(target: Cell): HTMLElement | undefined {
-    return target.node;
+  getElement(comment: IComment, target?: Cell): HTMLElement | undefined {
+    return target?.node ?? this.targetFromJSON(comment.target)?.node;
   }
 
   private _tracker: INotebookTracker;
@@ -171,31 +168,10 @@ export class CellSelectionCommentFactory extends ACommentFactory<Cell> {
 
     const cellSelectionComment = json as unknown as ICellSelectionComment;
     const { from, to } = range as CodeMirror.MarkerRange;
-    console.log('from, to', mark, from, to);
-    cellSelectionComment.target.start = this._toCodeEditorPosition(from);
-    cellSelectionComment.target.end = this._toCodeEditorPosition(to);
-
-    console.log('cellSelectionComment after', cellSelectionComment);
+    cellSelectionComment.target.start = Private.toCodeEditorPosition(from);
+    cellSelectionComment.target.end = Private.toCodeEditorPosition(to);
 
     return cellSelectionComment as unknown as PartialJSONObject;
-  }
-
-  private _toCodeMirrorPosition(
-    pos: CodeEditor.IPosition
-  ): CodeMirror.Position {
-    return {
-      line: pos.line,
-      ch: pos.column
-    };
-  }
-
-  private _toCodeEditorPosition(
-    pos: CodeMirror.Position
-  ): CodeEditor.IPosition {
-    return {
-      line: pos.line,
-      column: pos.ch
-    };
   }
 
   createWidget(
@@ -214,27 +190,10 @@ export class CellSelectionCommentFactory extends ACommentFactory<Cell> {
       return null;
     }
 
-    const cellSelectionComment = comment as ICellSelectionComment;
-
-    const color = comment.identity.color;
-    const r = parseInt(color.slice(1, 3), 16);
-    const g = parseInt(color.slice(3, 5), 16);
-    const b = parseInt(color.slice(5, 7), 16);
-
-    const { start, end } = cellSelectionComment.target;
-    const forward =
-      start.line < end.line ||
-      (start.line === end.line && start.column <= end.column);
-    const anchor = this._toCodeMirrorPosition(forward ? start : end);
-    const head = this._toCodeMirrorPosition(forward ? end : start);
-
-    const doc = (cell.editor as CodeMirrorEditor).doc;
-    const mark = doc.markText(anchor, head, {
-      className: 'jc-Highlight',
-      title: `${comment.identity.name}: ${truncate(comment.text, 140)}`,
-      css: `background-color: rgba( ${r}, ${g}, ${b}, 0.15)`,
-      attributes: { id: `CommentMark-${comment.id}` }
-    });
+    const mark = Private.markCommentSelection(
+      (cell.editor as CodeMirrorEditor).doc,
+      comment as ITextSelectionComment
+    );
 
     this._marks.set(comment.id, mark);
 
@@ -278,9 +237,9 @@ export class CellSelectionCommentFactory extends ACommentFactory<Cell> {
 
     const mark = this._marks.get(comment.id);
     if (mark == null) {
-      return this._getMockCommentPreviewText(
-        comment as ICellSelectionComment,
-        cell
+      return Private.getMockCommentPreviewText(
+        (cell.editor as CodeMirrorEditor).doc,
+        comment as ITextSelectionComment
       );
     }
 
@@ -296,24 +255,8 @@ export class CellSelectionCommentFactory extends ACommentFactory<Cell> {
     return truncate(text, 140);
   }
 
-  private _getMockCommentPreviewText(
-    comment: ICellSelectionComment,
-    cell: Cell
-  ): string {
-    const doc = (cell.editor as CodeMirrorEditor).doc;
-    const { start, end } = comment.target;
-    const forward =
-      start.line < end.line ||
-      (start.line === end.line && start.column <= end.column);
-    const from = this._toCodeMirrorPosition(forward ? start : end);
-    const to = this._toCodeMirrorPosition(forward ? end : start);
-    const text = doc.getRange(from, to);
-
-    return truncate(text, 140);
-  }
-
-  getElement(target: Cell): HTMLElement | undefined {
-    return target.node;
+  getElement(comment: IComment, target?: Cell): HTMLElement | undefined {
+    return target?.node ?? this.targetFromJSON(comment.target)?.node;
   }
 
   private _tracker: INotebookTracker;
@@ -328,8 +271,8 @@ export class HTMLElementCommentFactory extends ACommentFactory<HTMLElement> {
     console.log(this._root);
   }
 
-  getElement(target: HTMLElement): HTMLElement {
-    return target;
+  getElement(comment: IComment, target?: HTMLElement): HTMLElement | undefined {
+    return target ?? this.targetFromJSON(comment.target);
   }
 
   targetToJSON(target: HTMLElement): PartialJSONValue {
@@ -354,7 +297,10 @@ export class HTMLElementCommentFactory extends ACommentFactory<HTMLElement> {
 }
 
 export class TextSelectionCommentFactory extends ACommentFactory<CodeEditorWrapper> {
-  constructor(options: ACommentFactory.IOptions, tracker: WidgetTracker) {
+  constructor(
+    options: ACommentFactory.IOptions,
+    tracker: WidgetTracker<CodeEditorWrapper>
+  ) {
     super({ type: options.type });
     this._tracker = tracker;
   }
@@ -365,6 +311,7 @@ export class TextSelectionCommentFactory extends ACommentFactory<CodeEditorWrapp
     target?: CodeEditorWrapper
   ): CommentWidget<CodeEditorWrapper> | null {
     const wrapper = target ?? this.targetFromJSON(comment.target);
+    console.log('tracker', this._tracker);
     if (wrapper == null) {
       console.warn('no valid selection for: ', comment);
       return null;
@@ -374,47 +321,17 @@ export class TextSelectionCommentFactory extends ACommentFactory<CodeEditorWrapp
     if (widget == null) {
       return null;
     }
-    const selectionsMap = wrapper.editor.model.selections;
 
-    let tempSelections = selectionsMap.get(
-      (wrapper.parent as DocumentWidget)?.context.path
+    const mark = Private.markCommentSelection(
+      (wrapper.editor as CodeMirrorEditor).doc,
+      comment as ITextSelectionComment
     );
-    let selections = [];
-    if (tempSelections != null) {
-      selections = JSON.parse(JSON.stringify(tempSelections));
-    }
 
-    const { start, end } = comment.target as any as ISelection;
-    selections.push({
-      start,
-      end,
-      style: {
-        className: 'jc-Highlight',
-        color: 'black',
-        displayName: comment.identity.name
-      },
-      uuid: comment.id
-    });
-
-    selectionsMap.set(
-      (wrapper.parent as DocumentWidget)?.context.path,
-      selections
-    );
+    this._marks.set(comment.id, mark);
 
     widget.disposed.connect(() => {
-      console.warn('disposing');
-      const tempSels = selectionsMap.get(
-        (wrapper.parent as DocumentWidget)?.context.path
-      );
-      let sels: CodeEditor.ITextSelection[] = [];
-      if (tempSels != null) {
-        sels = JSON.parse(JSON.stringify(tempSels));
-      }
-      const newSels = sels.filter(sel => sel.uuid !== comment.id);
-      selectionsMap.set(
-        (wrapper.parent as DocumentWidget)?.context.path,
-        newSels
-      );
+      this._marks.delete(comment.id);
+      mark.clear();
     });
 
     return widget;
@@ -429,20 +346,13 @@ export class TextSelectionCommentFactory extends ACommentFactory<CodeEditorWrapp
       [start, end] = [end, start];
     }
     return {
-      editorID: (wrapper.parent as DocumentWidget).context.path,
       start,
       end
     };
   }
 
   targetFromJSON(json: PartialJSONValue): CodeEditorWrapper | undefined {
-    if (!(json instanceof Object && 'editorID' in json)) {
-      return;
-    }
-    return this._tracker.filter(
-      widget =>
-        (widget.parent as DocumentWidget).context.path === json['editorID']
-    )[0] as CodeEditorWrapper;
+    return this._tracker.currentWidget ?? undefined;
   }
 
   getPreviewText(comment: IComment, target?: CodeEditorWrapper): string {
@@ -452,30 +362,36 @@ export class TextSelectionCommentFactory extends ACommentFactory<CodeEditorWrapp
       return '';
     }
 
-    const text = wrapper.editor.model.value.text;
-    const textComment = comment as ITextSelectionComment;
-    const { start, end } = textComment.target;
+    const doc = (wrapper.editor as CodeMirrorEditor).doc;
 
-    let startIndex = wrapper.editor.getOffsetAt(start);
-    let endIndex = wrapper.editor.getOffsetAt(end);
-
-    if (startIndex > endIndex) {
-      [startIndex, endIndex] = [endIndex, startIndex];
+    const mark = this._marks.get(comment.id);
+    if (mark == null) {
+      return Private.getMockCommentPreviewText(
+        doc,
+        comment as ITextSelectionComment
+      );
     }
 
-    let previewText = text.slice(startIndex, endIndex);
-    if (previewText.length > 140) {
-      return previewText.slice(0, 140) + '...';
+    const range = mark.find();
+    if (range == null) {
+      return '';
     }
 
-    return previewText;
+    const { from, to } = range as CodeMirror.MarkerRange;
+    const text = doc.getRange(from, to);
+
+    return truncate(text, 140);
   }
 
-  getElement(target: CodeEditorWrapper) {
-    return target.node;
+  getElement(
+    comment: IComment,
+    target?: CodeEditorWrapper
+  ): HTMLElement | undefined {
+    return document.getElementById(`CommentMark-${comment.id}`) ?? undefined;
   }
 
-  private _tracker: WidgetTracker;
+  private _tracker: WidgetTracker<CodeEditorWrapper>;
+  private _marks = new Map<string, CodeMirror.TextMarker>();
 }
 
 export namespace HTMLElementCommentFactory {
@@ -501,12 +417,71 @@ export namespace ACommentFactory {
   }
 }
 
-//function that converts a line-column pairing to an index
-export function lineToIndex(str: string, line: number, col: number): number {
-  if (line == 0) {
-    return col;
-  } else {
-    let arr = str.split('\n');
-    return arr.slice(0, line).join('\n').length + col + 1;
+namespace Private {
+  //function that converts a line-column pairing to an index
+  export function lineToIndex(str: string, line: number, col: number): number {
+    if (line == 0) {
+      return col;
+    } else {
+      let arr = str.split('\n');
+      return arr.slice(0, line).join('\n').length + col + 1;
+    }
+  }
+
+  export function markCommentSelection(
+    doc: CodeMirror.Doc,
+    comment: ITextSelectionComment
+  ): CodeMirror.TextMarker {
+    const color = comment.identity.color;
+    const r = parseInt(color.slice(1, 3), 16);
+    const g = parseInt(color.slice(3, 5), 16);
+    const b = parseInt(color.slice(5, 7), 16);
+
+    const { start, end } = comment.target;
+    const forward =
+      start.line < end.line ||
+      (start.line === end.line && start.column <= end.column);
+    const anchor = toCodeMirrorPosition(forward ? start : end);
+    const head = toCodeMirrorPosition(forward ? end : start);
+
+    return doc.markText(anchor, head, {
+      className: 'jc-Highlight',
+      title: `${comment.identity.name}: ${truncate(comment.text, 140)}`,
+      css: `background-color: rgba( ${r}, ${g}, ${b}, 0.15)`,
+      attributes: { id: `CommentMark-${comment.id}` }
+    });
+  }
+
+  export function toCodeMirrorPosition(
+    pos: CodeEditor.IPosition
+  ): CodeMirror.Position {
+    return {
+      line: pos.line,
+      ch: pos.column
+    };
+  }
+
+  export function toCodeEditorPosition(
+    pos: CodeMirror.Position
+  ): CodeEditor.IPosition {
+    return {
+      line: pos.line,
+      column: pos.ch
+    };
+  }
+
+  export function getMockCommentPreviewText(
+    doc: CodeMirror.Doc,
+    comment: ITextSelectionComment
+  ): string {
+    const { start, end } = comment.target;
+    const forward =
+      start.line < end.line ||
+      (start.line === end.line && start.column <= end.column);
+    const from = toCodeMirrorPosition(forward ? start : end);
+    const to = toCodeMirrorPosition(forward ? end : start);
+    const text = doc.getRange(from, to);
+
+    return truncate(text, 140);
   }
 }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -311,7 +311,6 @@ export class TextSelectionCommentFactory extends ACommentFactory<CodeEditorWrapp
     target?: CodeEditorWrapper
   ): CommentWidget<CodeEditorWrapper> | null {
     const wrapper = target ?? this.targetFromJSON(comment.target);
-    console.log('tracker', this._tracker);
     if (wrapper == null) {
       console.warn('no valid selection for: ', comment);
       return null;

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -336,6 +336,38 @@ export class TextSelectionCommentFactory extends ACommentFactory<CodeEditorWrapp
     return widget;
   }
 
+  toJSON(comment: IComment): PartialJSONValue {
+    const wrapper = this.targetFromJSON(comment.target);
+    if (wrapper == null) {
+      return 'error: code editor wrapper not found';
+    }
+
+    const json = super.toJSON(comment);
+
+    const mark = this._marks.get(comment.id);
+    if (mark == null) {
+      console.warn(
+        'no mark found--serializing based on initial text selection position'
+      );
+      return json;
+    }
+
+    const range = mark.find();
+    if (range == null) {
+      console.warn(
+        'mark no longer exists in code editor--serializing based on initial text selection position'
+      );
+      return json;
+    }
+
+    const textSelectionComment = json as unknown as ICellSelectionComment;
+    const { from, to } = range as CodeMirror.MarkerRange;
+    textSelectionComment.target.start = Private.toCodeEditorPosition(from);
+    textSelectionComment.target.end = Private.toCodeEditorPosition(to);
+
+    return textSelectionComment as unknown as PartialJSONObject;
+  }
+
   targetToJSON(wrapper: CodeEditorWrapper): PartialJSONValue {
     let { start, end } = wrapper.editor.getSelection();
     if (

--- a/src/index.ts
+++ b/src/index.ts
@@ -476,7 +476,6 @@ function addCommands(
       }
 
       void fileWidget.context.save();
-      console.log('saved');
     }
   });
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -47,9 +47,7 @@ export class CommentFileModel implements DocumentRegistry.IModel {
   toJSON(): PartialJSONValue {
     return this.comments.map((comment: IComment) => {
       const factory = this.registry.getFactory(comment.type);
-      const json = factory!.toJSON(comment);
-      console.log('json', json);
-      return json;
+      return factory!.toJSON(comment);
     });
   }
 
@@ -59,7 +57,6 @@ export class CommentFileModel implements DocumentRegistry.IModel {
   fromJSON(value: PartialJSONValue): void {
     this.ymodel.transact(() => {
       const comments = this.comments;
-      console.log('fromJSON: comments', comments);
       comments.delete(0, comments.length);
       comments.push(value as any as IComment[]);
     });

--- a/src/model.ts
+++ b/src/model.ts
@@ -418,7 +418,6 @@ export class CommentFileModel implements DocumentRegistry.IModel {
   }
 
   get contentChanged(): ISignal<this, void> {
-    this.dirty = true;
     return this._contentChanged;
   }
 

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -158,7 +158,6 @@ export class CommentPanel extends Panel implements ICommentPanel {
       sourcePath === '' ||
       (this._sourcePath && this._sourcePath === sourcePath)
     ) {
-      console.log('sourcePath is emtpy or same as old sourcePath; returning');
       return;
     }
 
@@ -172,7 +171,6 @@ export class CommentPanel extends Panel implements ICommentPanel {
       const oldWidget = this._fileWidget;
       oldWidget.hide();
       await oldWidget.context.save();
-      console.log('done saving', oldWidget);
       oldWidget.dispose();
     }
 

--- a/src/panelHeaderWidget.tsx
+++ b/src/panelHeaderWidget.tsx
@@ -142,15 +142,6 @@ export class PanelHeader extends ReactWidget {
   }
 
   render(): ReactRenderElement {
-    const save = () => {
-      const fileWidget = this._panel.fileWidget;
-      if (fileWidget == null) {
-        return;
-      }
-
-      void fileWidget.context.save();
-    };
-
     const refresh = () => {
       const fileWidget = this._panel.fileWidget;
       if (fileWidget == null) {
@@ -158,6 +149,16 @@ export class PanelHeader extends ReactWidget {
       }
 
       fileWidget.initialize();
+    };
+
+    const save = () => {
+      const fileWidget = this._panel.fileWidget;
+      if (fileWidget == null) {
+        return;
+      }
+
+      void fileWidget.context.save();
+      refresh();
     };
 
     return (

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -500,6 +500,16 @@ export class CommentWidget<T> extends ReactWidget implements ICommentWidget<T> {
   }
 
   /**
+   * Scrolls to the comment's target, if it exists
+   */
+  private _scrollToTarget(): void {
+    const element = this.factory.getElement(this.comment!);
+    if (element != null) {
+      element.scrollIntoView({ behavior: 'smooth' });
+    }
+  }
+
+  /**
    * Sets the widget focus and active id on click.
    *
    * A building block of other click handlers.
@@ -541,6 +551,7 @@ export class CommentWidget<T> extends ReactWidget implements ICommentWidget<T> {
   protected _handleUserClick(event: React.MouseEvent): void {
     console.log('clicked user photo!');
     this._setClickFocus(event);
+    this._scrollToTarget();
   }
 
   /**
@@ -562,6 +573,8 @@ export class CommentWidget<T> extends ReactWidget implements ICommentWidget<T> {
     } else {
       this.replyAreaHidden = true;
     }
+
+    this._scrollToTarget();
   }
 
   /**
@@ -569,6 +582,7 @@ export class CommentWidget<T> extends ReactWidget implements ICommentWidget<T> {
    */
   protected _handleReplyClick(event: React.MouseEvent): void {
     this._setClickFocus(event);
+    this._scrollToTarget();
   }
 
   /**
@@ -576,7 +590,7 @@ export class CommentWidget<T> extends ReactWidget implements ICommentWidget<T> {
    */
   protected _handleBodyClick(event: React.MouseEvent): void {
     this._setClickFocus(event);
-    // this.openEditActive();
+    this._scrollToTarget();
   }
 
   /**


### PR DESCRIPTION
Addresses issues #122 and #111

## Changes
- Made text selections relative. They now expand/shrink to accommodate changes to the source text.
- Text selections are now in the user's color and have the comment text in the tooltip.
- Made some timing fixes to the model loading/saving system.
- Comments are now serialized by the `toJSON` method of their factory.
- Added a "save" option to the comment panel context menu.
- Fixed a bug where creating a new comment file would log a 404 error to the console.
- Fixed a bug where switching documents would cause comments from both documents to be briefly visible.
- Made clicking a comment scroll to the target of that comment.